### PR TITLE
Update WARN in SBT to resolve hostname faster

### DIFF
--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -49,7 +49,7 @@ class JUnitXmlTestsListener(val outputDir: String, logger: Logger) extends Tests
       logger.warn(
         s"Getting the hostname $name was slow (${elapsed / 1.0e6} ms). " +
           "This is likely because the computer's hostname is not set. You can set the " +
-          "hostname with the command: scutil --set HostName $(scutil --get LocalHostName)."
+          """hostname with the command: scutil --set HostName "$(scutil --get LocalHostName).local"."""
       )
     }
     name


### PR DESCRIPTION
Running the command referenced in this warning did not actually resolve the issue when resolving the hostname. Turns out adding `.local` to the end of the HostName was necessary.

See the 2nd answer here:

https://apple.stackexchange.com/questions/175320/why-is-my-hostname-resolution-taking-so-long